### PR TITLE
feat: add version flag to display current version of clipper

### DIFF
--- a/main.go
+++ b/main.go
@@ -9,9 +9,12 @@ import (
 	"github.com/atotto/clipboard"
 )
 
+const version = "1.1.0"
+
 func main() {
 	// Define flags
 	directText := flag.String("c", "", "Copy text directly from command line argument")
+	showVersion := flag.Bool("v", false, "Show the current version of the clipper tool")
 
 	// Custom usage message
 	flag.Usage = func() {
@@ -20,10 +23,17 @@ func main() {
 		fmt.Fprintf(flag.CommandLine.Output(), "  clipper [arguments]\n")
 		fmt.Fprintf(flag.CommandLine.Output(), "\nArguments:\n")
 		fmt.Fprintf(flag.CommandLine.Output(), "  -c <string>    Copy text directly from command line argument\n")
+		fmt.Fprintf(flag.CommandLine.Output(), "  -v             Show the current version of the clipper tool\n")
 		fmt.Fprintf(flag.CommandLine.Output(), "\nIf no file or text is provided, reads from standard input.\n")
 	}
 
 	flag.Parse()
+
+	// Check if the version flag is set
+	if *showVersion {
+		fmt.Printf("Clipper %s\n", version)
+		return
+	}
 
 	var contentStr string
 

--- a/main.go
+++ b/main.go
@@ -9,7 +9,7 @@ import (
 	"github.com/atotto/clipboard"
 )
 
-const version = "1.1.0"
+const version = "1.2.0"
 
 func main() {
 	// Define flags


### PR DESCRIPTION
- Defined a constant for the current version of the tool.
- Added a new flag '-v' to display the current version.
- Updated the usage message to include the new version flag.