### PR TITLE
feat: improve performance with buffered I/O (bufio) for large file handling

### DIFF
--- a/tests/clipper_test.go
+++ b/tests/clipper_test.go
@@ -1,7 +1,9 @@
 package clipper
 
 import (
+	"bufio"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/atotto/clipboard"
@@ -92,6 +94,53 @@ func TestClipboardWriter(t *testing.T) {
 			t.Errorf("Expected '%s', got '%s'", mockTextContent, clipboardContent)
 		}
 	})
+}
+
+func TestReadContent(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		expected    string
+		expectError bool
+	}{
+		{
+			name:        "Single line content",
+			input:       "Hello, World!",
+			expected:    "Hello, World!",
+			expectError: false,
+		},
+		{
+			name:        "Multiple lines content",
+			input:       "Hello, World!\nThis is a test.",
+			expected:    "Hello, World!\nThis is a test.",
+			expectError: false,
+		},
+		{
+			name:        "Empty content",
+			input:       "",
+			expected:    "",
+			expectError: false,
+		},
+		{
+			name:        "Content with EOF error",
+			input:       "Hello, World!",
+			expected:    "Hello, World!",
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reader := bufio.NewReader(strings.NewReader(tt.input))
+			output, err := clipper.ReadContent(reader)
+			if (err != nil) != tt.expectError {
+				t.Fatalf("ReadContent() error = %v, expectError %v", err, tt.expectError)
+			}
+			if output != tt.expected {
+				t.Errorf("ReadContent() = %v, want %v", output, tt.expected)
+			}
+		})
+	}
 }
 
 func TestParseContent(t *testing.T) {


### PR DESCRIPTION
This pull request addresses issue #22 by improving the performance of reading contents (e.g., file nor stdin) in Clipper using buffered I/O (`bufio`). 

**Changes:**
- **Refactor:** Implement buffered I/O for reading content
  - Use `bufio.Reader` to handle large sums of data efficiently.
  - Extract common read logic into a new `ReadContent` function.

- **Test:** Add unit tests for `ReadContent` function
  - Added test cases for single line, multiple lines, empty content, and EOF error scenarios.
  - Organized tests using `t.Run` for better readability.

**Tasks:**
- [x] Implement buffered I/O with `bufio.Reader`
- [x] Extract common read logic into `ReadContent` function
- [x] Add unit tests for `ReadContent`
- [x] Organize tests using `t.Run`

These changes were an attempt to enhance the performance of Clipper, especially when dealing with large files. However, based on the benchmark results, the non-buffered I/O implementation remains the better option for Clipper's performance needs.

### Reference

- See [Clipper Performance Evaluation of Buffered I/O Implementation](https://github.com/supitsdu/clipper/issues/22#issuecomment-2198430956)
