### PR TITLE
refactor(clipper/options): Enhance version handling and remove pointers for improved usability

### DIFF
--- a/cli/clipper/clipper.go
+++ b/cli/clipper/clipper.go
@@ -23,7 +23,7 @@ func (c DefaultClipboardWriter) Write(content string) error {
 
 // Run executes the core logic of the Clipper tool.
 func Run(config *options.Config, writer ClipboardWriter) (string, error) {
-	readers := reader.GetReaders(config.Args)
+	readers := reader.GetReaders(config.Args...)
 
 	// Aggregate the content from the provided sources.
 	content, err := reader.ParseContent(config.DirectText, readers...)

--- a/cli/clipper/clipper.go
+++ b/cli/clipper/clipper.go
@@ -21,12 +21,8 @@ func (c DefaultClipboardWriter) Write(content string) error {
 	return clipboard.WriteAll(content)
 }
 
-// Run executes the clipper tool logic based on the provided configuration.
+// Run executes the core logic of the Clipper tool.
 func Run(config *options.Config, writer ClipboardWriter) (string, error) {
-	if *config.ShowVersion {
-		return options.Version, nil
-	}
-
 	readers := reader.GetReaders(config.Args)
 
 	// Aggregate the content from the provided sources.
@@ -40,5 +36,5 @@ func Run(config *options.Config, writer ClipboardWriter) (string, error) {
 		return "", fmt.Errorf("copying content to clipboard: %w", err)
 	}
 
-	return "updated clipboard successfully. Ready to paste!", nil
+	return "Updated clipboard successfully. Ready to paste!", nil
 }

--- a/cli/main.go
+++ b/cli/main.go
@@ -9,17 +9,20 @@ import (
 )
 
 func main() {
-	config := options.ParseFlags()
-	writer := clipper.DefaultClipboardWriter{}
+	config := options.ParseFlags() // Parse command-line flags
 
-	msg, err := clipper.Run(config, writer)
-	if err != nil {
-		fmt.Printf("Error %s\n", err)
-		os.Exit(1)
-	}
-
-	if msg != "" {
-		fmt.Printf("Clipper %s\n", msg)
+	if *config.ShowVersion {
+		fmt.Printf("Clipper %s\n", options.GetVersion())
 		os.Exit(0)
 	}
+
+	writer := clipper.DefaultClipboardWriter{} // Create the default clipboard writer
+
+	msg, err := clipper.Run(config, writer) // Run the main Clipper logic
+	if err != nil {
+		fmt.Printf("Error %s\n", err)
+		os.Exit(1) // Exit with an error code
+	}
+
+	fmt.Println(msg)
 }

--- a/cli/main.go
+++ b/cli/main.go
@@ -11,7 +11,7 @@ import (
 func main() {
 	config := options.ParseFlags() // Parse command-line flags
 
-	if *config.ShowVersion {
+	if config.ShowVersion {
 		fmt.Printf("Clipper %s\n", options.GetVersion())
 		os.Exit(0)
 	}

--- a/cli/options/options.go
+++ b/cli/options/options.go
@@ -7,8 +7,8 @@ import (
 )
 
 type Config struct {
-	DirectText  *string
-	ShowVersion *bool
+	DirectText  string
+	ShowVersion bool
 	Args        []string
 }
 
@@ -45,8 +45,8 @@ func ParseFlags() *Config {
 	flag.Parse()
 
 	return &Config{
-		DirectText:  directText,
-		ShowVersion: showVersion,
+		DirectText:  *directText,
+		ShowVersion: *showVersion,
 		Args:        flag.Args(),
 	}
 }

--- a/cli/options/options.go
+++ b/cli/options/options.go
@@ -3,6 +3,7 @@ package options
 import (
 	"flag"
 	"fmt"
+	"strings"
 )
 
 type Config struct {
@@ -11,7 +12,20 @@ type Config struct {
 	Args        []string
 }
 
-const Version = "1.5.0"
+// Package-level variables for version information (set at build time or default)
+var (
+	Version       = "dev"        // Default for development builds
+	BuildMetadata = "git/source" // Default for development builds
+)
+
+// GetVersion formats the version string for display
+func GetVersion() string {
+	if BuildMetadata != "" {
+		return strings.TrimSpace(Version) + " " + strings.TrimSpace(BuildMetadata)
+	} else {
+		return strings.TrimSpace(Version)
+	}
+}
 
 // ParseFlags parses the command-line flags and arguments.
 func ParseFlags() *Config {

--- a/cli/reader/reader.go
+++ b/cli/reader/reader.go
@@ -43,7 +43,7 @@ func (s StdinContentReader) Read() (string, error) {
 
 // ReadContentConcurrently reads content from multiple readers concurrently and returns the results.
 // This function utilizes goroutines to perform concurrent reads, improving performance for multiple files.
-func ReadContentConcurrently(readers []ContentReader) ([]string, error) {
+func ReadContentConcurrently(readers ...ContentReader) ([]string, error) {
 	var wg sync.WaitGroup
 	var mu sync.Mutex
 	errChan := make(chan error, len(readers)) // Channel to capture errors
@@ -79,7 +79,7 @@ func ReadContentConcurrently(readers []ContentReader) ([]string, error) {
 
 // AggregateContent aggregates the content from the provided results and returns it as a single string.
 // It combines the content of all readers into a single string with newline separators.
-func AggregateContent(results []string) string {
+func AggregateContent(results ...string) string {
 	var sb strings.Builder
 	for _, content := range results {
 		if content != "" { // Ensure non-empty content is aggregated
@@ -91,26 +91,26 @@ func AggregateContent(results []string) string {
 
 // ParseContent aggregates content from the provided readers, or returns the direct text if provided.
 // This function first checks for direct text input, then reads from the provided readers concurrently.
-func ParseContent(directText *string, readers ...ContentReader) (string, error) {
-	if directText != nil && *directText != "" {
-		return *directText, nil // Return direct text if provided
+func ParseContent(directText string, readers ...ContentReader) (string, error) {
+	if directText != "" {
+		return directText, nil // Return direct text if provided
 	}
 
 	if len(readers) == 0 {
 		return "", fmt.Errorf("no content readers provided")
 	}
 
-	results, err := ReadContentConcurrently(readers) // Read content concurrently
+	results, err := ReadContentConcurrently(readers...) // Read content concurrently
 	if err != nil {
 		return "", err
 	}
 
-	return AggregateContent(results), nil // Aggregate and return the content
+	return AggregateContent(results...), nil // Aggregate and return the content
 }
 
 // GetReaders constructs the appropriate ContentReaders based on the provided file paths or lack thereof.
 // If no targets are provided, it defaults to using StdinContentReader.
-func GetReaders(targets []string) []ContentReader {
+func GetReaders(targets ...string) []ContentReader {
 	if len(targets) == 0 {
 		// If no file paths are provided, use StdinContentReader to read from stdin.
 		return []ContentReader{StdinContentReader{}}

--- a/tests/reader/reader_test.go
+++ b/tests/reader/reader_test.go
@@ -85,7 +85,7 @@ func TestParseContent(t *testing.T) {
 		reader2 := reader.FileContentReader{FilePath: file2.Name()}
 
 		// Execute the function under test
-		actual, err := reader.ParseContent(nil, reader1, reader2)
+		actual, err := reader.ParseContent("", reader1, reader2)
 		if err != nil {
 			t.Fatalf("Expected no error, got %v", err)
 		}
@@ -111,7 +111,7 @@ func TestParseContent(t *testing.T) {
 		testReader := reader.FileContentReader{FilePath: emptyFile.Name()}
 
 		// Execute the function under test with the empty file
-		actual, err := reader.ParseContent(nil, testReader)
+		actual, err := reader.ParseContent("", testReader)
 		if err != nil {
 			t.Fatalf("Expected no error, got: %v", err)
 		}
@@ -127,7 +127,7 @@ func TestParseContent(t *testing.T) {
 
 	t.Run("InvalidNilInput", func(t *testing.T) {
 		// Execute the function under test with no input arguments
-		_, err := reader.ParseContent(nil)
+		_, err := reader.ParseContent("")
 		if err == nil {
 			t.Fatalf("Expected error, got %v", err)
 		}
@@ -141,7 +141,7 @@ func TestParseContent(t *testing.T) {
 		testReader := reader.FileContentReader{FilePath: invalidPath}
 
 		// Execute the function under test with the invalid file path
-		_, err := reader.ParseContent(nil, testReader)
+		_, err := reader.ParseContent("", testReader)
 		if err == nil {
 			t.Fatalf("Expected an error, but got none")
 		}
@@ -162,7 +162,7 @@ func TestParseContent(t *testing.T) {
 		testReader := reader.FileContentReader{FilePath: largeFile.Name()}
 
 		// Execute the function under test with the large file
-		actual, err := reader.ParseContent(nil, testReader)
+		actual, err := reader.ParseContent("", testReader)
 		if err != nil {
 			t.Fatalf("Expected no error, got %v", err)
 		}
@@ -176,7 +176,7 @@ func TestParseContent(t *testing.T) {
 	t.Run("DirectText", func(t *testing.T) {
 		// Test with direct text
 		directText := tests.SampleText_32
-		content, err := reader.ParseContent(&directText)
+		content, err := reader.ParseContent(directText)
 		if err != nil {
 			t.Errorf("Error parsing content: %v", err)
 		}
@@ -194,7 +194,7 @@ func TestParseContent(t *testing.T) {
 
 		testReader := reader.FileContentReader{FilePath: tmpFile.Name()}
 
-		content, err := reader.ParseContent(nil, testReader)
+		content, err := reader.ParseContent("", testReader)
 		if err != nil {
 			t.Errorf("Error parsing content: %v", err)
 		}


### PR DESCRIPTION
This pull request enhances our Clipper codebase by addressing version management and configuration handling:

* **Implemented dynamic versioning** to distinguish between development builds ("dev git/source") and release builds ("vX.Y.Z OS/ARCH"). 

**Tasks:**
*   [x] Modified `options.go` to use package-level variables for version information and provide a `GetVersion()` function.
*   [x] Updated the Makefile to set version and build metadata using `-ldflags`.
*   [x] Adjusted `main.go` to utilize `GetVersion()` for displaying the version.
*   [x] Refactored `options.Config` by removing unnecessary pointers from the `DirectText` and `ShowVersion` fields.
*   [x] Updated unit tests to accommodate changes.

**Benefits:**
* Improved clarity and user-friendliness of version information.
* Simplified code and reduced potential for errors by eliminating pointers.


Closes #36
Closes #30 
